### PR TITLE
Fluid Builder stuff

### DIFF
--- a/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
+++ b/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
@@ -18,10 +18,12 @@ import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Table;
+import com.tterrag.registrate.util.FluidAttributes;
 import net.fabricmc.fabric.api.item.v1.FabricItemSettings;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricEntityTypeBuilder;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.fluid.Fluid;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -1008,17 +1010,17 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
         return fluid(self(), stillTexture, flowingTexture);
     }
 
-//    public FluidBuilder<SimpleFlowableFluid.Flowing, S> fluid(Identifier stillTexture, Identifier flowingTexture, NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory) {
-//        return fluid(self(), stillTexture, flowingTexture, attributesFactory);
-//    }
+    public FluidBuilder<SimpleFlowableFluid.Flowing, S> fluid(Identifier stillTexture, Identifier flowingTexture, NonNullBiFunction<FluidAttributes, Fluid, FluidAttributes> attributesFactory) {
+        return fluid(self(), stillTexture, flowingTexture, attributesFactory);
+    }
 
     public <T extends SimpleFlowableFluid> FluidBuilder<T, S> fluid(Identifier stillTexture, Identifier flowingTexture, NonNullFunction<SimpleFlowableFluid.Properties, T> factory) {
         return fluid(self(), stillTexture, flowingTexture, factory);
     }
 
-//    public <T extends SimpleFlowableFluid> FluidBuilder<T, S> fluid(Identifier stillTexture, Identifier flowingTexture, NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, NonNullFunction<SimpleFlowableFluid.Properties, T> factory) {
-//        return fluid(self(), stillTexture, flowingTexture, attributesFactory, factory);
-//    }
+    public <T extends SimpleFlowableFluid> FluidBuilder<T, S> fluid(Identifier stillTexture, Identifier flowingTexture, NonNullBiFunction<FluidAttributes, Fluid, FluidAttributes> attributesFactory, NonNullFunction<SimpleFlowableFluid.Properties, T> factory) {
+        return fluid(self(), stillTexture, flowingTexture, attributesFactory, factory);
+    }
 
     public FluidBuilder<SimpleFlowableFluid.Flowing, S> fluid(String name) {
         return fluid(self(), name);
@@ -1028,17 +1030,17 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
         return fluid(self(), name, stillTexture, flowingTexture);
     }
 
-//    public FluidBuilder<SimpleFlowableFluid.Flowing, S> fluid(String name, Identifier stillTexture, Identifier flowingTexture, NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory) {
-//        return fluid(self(), name, stillTexture, flowingTexture, attributesFactory);
-//    }
+    public FluidBuilder<SimpleFlowableFluid.Flowing, S> fluid(String name, Identifier stillTexture, Identifier flowingTexture, NonNullBiFunction<FluidAttributes, Fluid, FluidAttributes> attributesFactory) {
+        return fluid(self(), name, stillTexture, flowingTexture, attributesFactory);
+    }
 
     public <T extends SimpleFlowableFluid> FluidBuilder<T, S> fluid(String name, Identifier stillTexture, Identifier flowingTexture, NonNullFunction<SimpleFlowableFluid.Properties, T> factory) {
         return fluid(self(), name, stillTexture, flowingTexture, factory);
     }
 
-//    public <T extends SimpleFlowableFluid> FluidBuilder<T, S> fluid(String name, Identifier stillTexture, Identifier flowingTexture, NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, NonNullFunction<SimpleFlowableFluid.Properties, T> factory) {
-//        return fluid(self(), name, stillTexture, flowingTexture, attributesFactory, factory);
-//    }
+    public <T extends SimpleFlowableFluid> FluidBuilder<T, S> fluid(String name, Identifier stillTexture, Identifier flowingTexture, NonNullBiFunction<FluidAttributes, Fluid, FluidAttributes> attributesFactory, NonNullFunction<SimpleFlowableFluid.Properties, T> factory) {
+        return fluid(self(), name, stillTexture, flowingTexture, attributesFactory, factory);
+    }
 
     public <P> FluidBuilder<SimpleFlowableFluid.Flowing, P> fluid(P parent) {
         return fluid(parent, currentName());
@@ -1048,17 +1050,17 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
         return fluid(parent, currentName(), stillTexture, flowingTexture);
     }
 
-//    public <P> FluidBuilder<SimpleFlowableFluid.Flowing, P> fluid(P parent, Identifier stillTexture, Identifier flowingTexture, NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory) {
-//        return fluid(parent, currentName(), stillTexture, flowingTexture, attributesFactory);
-//    }
+    public <P> FluidBuilder<SimpleFlowableFluid.Flowing, P> fluid(P parent, Identifier stillTexture, Identifier flowingTexture, NonNullBiFunction<FluidAttributes, Fluid, FluidAttributes> attributesFactory) {
+        return fluid(parent, currentName(), stillTexture, flowingTexture, attributesFactory);
+    }
 
     public <T extends SimpleFlowableFluid, P> FluidBuilder<T, P> fluid(P parent, Identifier stillTexture, Identifier flowingTexture, NonNullFunction<SimpleFlowableFluid.Properties, T> factory) {
         return fluid(parent, currentName(), stillTexture, flowingTexture, factory);
     }
 
-//    public <T extends SimpleFlowableFluid, P> FluidBuilder<T, P> fluid(P parent, Identifier stillTexture, Identifier flowingTexture, NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, NonNullFunction<SimpleFlowableFluid.Properties, T> factory) {
-//        return fluid(parent, currentName(), stillTexture, flowingTexture, attributesFactory, factory);
-//    }
+    public <T extends SimpleFlowableFluid, P> FluidBuilder<T, P> fluid(P parent, Identifier stillTexture, Identifier flowingTexture, NonNullBiFunction<FluidAttributes, Fluid, FluidAttributes> attributesFactory, NonNullFunction<SimpleFlowableFluid.Properties, T> factory) {
+        return fluid(parent, currentName(), stillTexture, flowingTexture, attributesFactory, factory);
+    }
 
     public <P> FluidBuilder<SimpleFlowableFluid.Flowing, P> fluid(P parent, String name) {
         return fluid(parent, name, new Identifier(getModid(), "block/" + currentName() + "_still"), new Identifier(getModid(), "block/" + currentName() + "_flow"));
@@ -1068,17 +1070,17 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
         return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, stillTexture, flowingTexture));
     }
 
-//    public <P> FluidBuilder<SimpleFlowableFluid.Flowing, P> fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture, NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory) {
-//        return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, stillTexture, flowingTexture, attributesFactory));
-//    }
+    public <P> FluidBuilder<SimpleFlowableFluid.Flowing, P> fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture, NonNullBiFunction<FluidAttributes, Fluid, FluidAttributes> attributesFactory) {
+        return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, stillTexture, flowingTexture, attributesFactory));
+    }
 
     public <T extends SimpleFlowableFluid, P> FluidBuilder<T, P> fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture, NonNullFunction<SimpleFlowableFluid.Properties, T> factory) {
         return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, stillTexture, flowingTexture, factory));
     }
 
-//    public <T extends SimpleFlowableFluid, P> FluidBuilder<T, P> fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture, NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, NonNullFunction<SimpleFlowableFluid.Properties, T> factory) {
-//        return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, stillTexture, flowingTexture, attributesFactory, factory));
-//    }
+    public <T extends SimpleFlowableFluid, P> FluidBuilder<T, P> fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture, NonNullBiFunction<FluidAttributes, Fluid, FluidAttributes> attributesFactory, NonNullFunction<SimpleFlowableFluid.Properties, T> factory) {
+        return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, stillTexture, flowingTexture, attributesFactory, factory));
+    }
 
     // Container
     public <T extends ScreenHandler, SC extends Screen & ScreenHandlerProvider<T>> ContainerBuilder<T, SC, S> container(ContainerFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {

--- a/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
@@ -3,16 +3,20 @@ package com.tterrag.registrate.builders;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Preconditions;
+import com.tterrag.registrate.util.FluidAttributes;
+import com.tterrag.registrate.util.nullness.*;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
 import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandler;
 import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandlerRegistry;
 import net.fabricmc.fabric.api.item.v1.FabricItemSettings;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
+import net.minecraft.util.Util;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Block;
@@ -36,10 +40,6 @@ import com.tterrag.registrate.fabric.SimpleFluidRenderHandler;
 import com.tterrag.registrate.util.NonNullLazyValue;
 import com.tterrag.registrate.util.entry.FluidEntry;
 import com.tterrag.registrate.util.entry.RegistryEntry;
-import com.tterrag.registrate.util.nullness.NonNullBiFunction;
-import com.tterrag.registrate.util.nullness.NonNullConsumer;
-import com.tterrag.registrate.util.nullness.NonNullFunction;
-import com.tterrag.registrate.util.nullness.NonNullSupplier;
 
 /**
  * A builder for fluids, allows for customization of the {@link SimpleFlowableFluid.Properties} and {@link FluidAttributes}, and creation of the source variant, fluid block, and bucket item, as well as
@@ -51,14 +51,7 @@ import com.tterrag.registrate.util.nullness.NonNullSupplier;
  *            Parent object type
  */
 public class FluidBuilder<T extends SimpleFlowableFluid, P> extends AbstractBuilder<Fluid, T, P, FluidBuilder<T, P>> {
-    
-//    private static class Builder extends FluidAttributes.Builder {
-//        
-//        protected Builder(Identifier still, Identifier flowing, BiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory) {
-//            super(still, flowing, attributesFactory);
-//        }
-//    }
-
+	
     /**
      * Create a new {@link FluidBuilder} and configure data. The created builder will use the default attributes class ({@link FluidAttributes}) and fluid class ({@link SimpleFlowableFluid.Flowing}).
      * 
@@ -79,9 +72,9 @@ public class FluidBuilder<T extends SimpleFlowableFluid, P> extends AbstractBuil
      * @return A new {@link FluidBuilder} with reasonable default data generators.
      * @see #create(AbstractRegistrate, Object, String, BuilderCallback, Identifier, Identifier, NonNullBiFunction, NonNullFunction)
      */
-//    public static <P> FluidBuilder<SimpleFlowableFluid.Flowing, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, Identifier stillTexture, Identifier flowingTexture) {
-//        return create(owner, parent, name, callback, stillTexture, flowingTexture/*, (NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes>) null*/);
-//    }
+    public static <P> FluidBuilder<SimpleFlowableFluid.Flowing, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, Identifier stillTexture, Identifier flowingTexture) {
+        return create(owner, parent, name, callback, stillTexture, flowingTexture, (NonNullBiFunction<FluidAttributes, Fluid, FluidAttributes>) null);
+    }
     
     /**
      * Create a new {@link FluidBuilder} and configure data. The created builder will use the default fluid class ({@link SimpleFlowableFluid.Flowing}).
@@ -105,9 +98,9 @@ public class FluidBuilder<T extends SimpleFlowableFluid, P> extends AbstractBuil
      * @return A new {@link FluidBuilder} with reasonable default data generators.
      * @see #create(AbstractRegistrate, Object, String, BuilderCallback, Identifier, Identifier, NonNullBiFunction, NonNullFunction)
      */
-    public static <P> FluidBuilder<SimpleFlowableFluid.Flowing, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, Identifier stillTexture, Identifier flowingTexture/*,
-            @Nullable NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory*/) {
-        return create(owner, parent, name, callback, stillTexture, flowingTexture, /*attributesFactory,*/ SimpleFlowableFluid.Flowing::new);
+    public static <P> FluidBuilder<SimpleFlowableFluid.Flowing, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, Identifier stillTexture, Identifier flowingTexture,
+            @Nullable NonNullBiFunction<FluidAttributes, Fluid, FluidAttributes> attributesFactory) {
+        return create(owner, parent, name, callback, stillTexture, flowingTexture, attributesFactory, SimpleFlowableFluid.Flowing::new);
     }
     
     /**
@@ -134,10 +127,10 @@ public class FluidBuilder<T extends SimpleFlowableFluid, P> extends AbstractBuil
      * @return A new {@link FluidBuilder} with reasonable default data generators.
      * @see #create(AbstractRegistrate, Object, String, BuilderCallback, Identifier, Identifier, NonNullBiFunction, NonNullFunction)
      */
-//    public static <T extends SimpleFlowableFluid, P> FluidBuilder<T, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, Identifier stillTexture, Identifier flowingTexture,
-//            NonNullFunction<SimpleFlowableFluid.Properties, T> factory) {
-//        return create(owner, parent, name, callback, stillTexture, flowingTexture, /*null,*/ factory);
-//    }
+    public static <T extends SimpleFlowableFluid, P> FluidBuilder<T, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, Identifier stillTexture, Identifier flowingTexture,
+            NonNullFunction<SimpleFlowableFluid.Properties, T> factory) {
+        return create(owner, parent, name, callback, stillTexture, flowingTexture, null, factory);
+    }
     
     /**
      * Create a new {@link FluidBuilder} and configure data. Used in lieu of adding side-effects to constructor, so that alternate initialization strategies can be done in subclasses.
@@ -174,8 +167,8 @@ public class FluidBuilder<T extends SimpleFlowableFluid, P> extends AbstractBuil
      * @return A new {@link FluidBuilder} with reasonable default data generators.
      */
     public static <T extends SimpleFlowableFluid, P> FluidBuilder<T, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, Identifier stillTexture, Identifier flowingTexture,
-            /*@Nullable NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory,*/ NonNullFunction<SimpleFlowableFluid.Properties, T> factory) {
-        FluidBuilder<T, P> ret = new FluidBuilder<>(owner, parent, name, callback, stillTexture, flowingTexture, /*attributesFactory,*/ factory)
+            @Nullable NonNullBiFunction<FluidAttributes, Fluid, FluidAttributes> attributesFactory, NonNullFunction<SimpleFlowableFluid.Properties, T> factory) {
+        FluidBuilder<T, P> ret = new FluidBuilder<>(owner, parent, name, callback, stillTexture, flowingTexture, attributesFactory, factory)
                 .defaultLang().defaultSource().defaultBlock().defaultBucket()
                 .tag(FluidTags.WATER);
 
@@ -186,26 +179,26 @@ public class FluidBuilder<T extends SimpleFlowableFluid, P> extends AbstractBuil
     private final Identifier flowingTexture;
     private final String sourceName;
     private final String bucketName;
-//    private final NonNullSupplier<FluidAttributes.Builder> attributes;
+    private final NonNullSupplier<FluidAttributes> attributes;
     private final NonNullFunction<SimpleFlowableFluid.Properties, T> factory;
 
     @Nullable
     private Boolean defaultSource, defaultBlock, defaultBucket;
 
-//    private NonNullConsumer<FluidAttributes.Builder> attributesCallback = $ -> {};
+    private NonNullConsumer<FluidAttributes> attributesCallback = $ -> {};
     private NonNullConsumer<SimpleFlowableFluid.Properties> properties;
     @Nullable
     private NonNullLazyValue<? extends SimpleFlowableFluid> source;
     private List<Identified<Fluid>> tags = new ArrayList<>();
 
     protected FluidBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, Identifier stillTexture, Identifier flowingTexture,
-            /*@Nullable BiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory,*/ NonNullFunction<SimpleFlowableFluid.Properties, T> factory) {
+						   @Nullable BiFunction<FluidAttributes, Fluid, FluidAttributes> attributesFactory, NonNullFunction<SimpleFlowableFluid.Properties, T> factory) {
         super(owner, parent, "flowing_" + name, callback, Fluid.class);
         this.stillTexture = stillTexture;
         this.flowingTexture = flowingTexture;
         this.sourceName = name;
         this.bucketName = name + "_bucket";
-//        this.attributes = () -> attributesFactory == null ? FluidAttributes.builder(stillTexture, flowingTexture) : new Builder(stillTexture, flowingTexture, attributesFactory);
+        this.attributes = () -> new FluidAttributes().stillTexture(stillTexture).flowingTexture(flowingTexture);
         this.factory = factory;
         
         String bucketName = this.bucketName;
@@ -221,10 +214,10 @@ public class FluidBuilder<T extends SimpleFlowableFluid, P> extends AbstractBuil
      *            The action to perform on the attributes
      * @return this {@link FluidBuilder}
      */
-//    public FluidBuilder<T, P> attributes(NonNullConsumer<FluidAttributes.Builder> cons) {
-//        attributesCallback = attributesCallback.andThen(cons);
-//        return this;
-//    }
+    public FluidBuilder<T, P> attributes(NonNullConsumer<FluidAttributes> cons) {
+        attributesCallback = attributesCallback.andThen(cons);
+        return this;
+    }
     
     /**
      * Modify the properties of the fluid. Modifications are done lazily, but the passed function is composed with the current one, and as such this method can be called multiple times to perform
@@ -240,6 +233,7 @@ public class FluidBuilder<T extends SimpleFlowableFluid, P> extends AbstractBuil
     }
 
     /**
+	 * Does not work currently.
      * Assign the default translation, as specified by {@link RegistrateLangProvider#getAutomaticName(NonNullSupplier)}. This is the default, so it is generally not necessary to call, unless for
      * undoing previous changes.
      * 
@@ -250,6 +244,7 @@ public class FluidBuilder<T extends SimpleFlowableFluid, P> extends AbstractBuil
     }
 
     /**
+	 * Does not work currently.
      * Set the translation for this fluid.
      * 
      * @param name
@@ -315,6 +310,7 @@ public class FluidBuilder<T extends SimpleFlowableFluid, P> extends AbstractBuil
     }
 
     /**
+	 * Does not work currently.
      * Create a {@link FluidBlock} for this fluid, which is created by the given factory, and return the builder for it so that further customization can be done.
      * 
      * @param <B>
@@ -332,7 +328,7 @@ public class FluidBuilder<T extends SimpleFlowableFluid, P> extends AbstractBuil
         return getOwner().<B, FluidBuilder<T, P>>block(this, sourceName, p -> factory.apply(supplier, p))
                 .properties(p -> FabricBlockSettings.copyOf(Blocks.WATER).dropsNothing())
 //                .properties(p -> {
-//                    // TODO is this ok?
+                    // TODO is this ok?
 //                    FluidAttributes attrs = this.attributes.get().build(Fluids.WATER);
 //                    return p.lightLevel($ -> attrs.getLuminosity());
 //                })
@@ -381,6 +377,7 @@ public class FluidBuilder<T extends SimpleFlowableFluid, P> extends AbstractBuil
     }
 
     /**
+	 * Does not work currently.
      * Create a {@link BucketItem} for this fluid, which is created by the given factory, and return the builder for it so that further customization can be done.
      * 
      * @param <I>
@@ -409,6 +406,7 @@ public class FluidBuilder<T extends SimpleFlowableFluid, P> extends AbstractBuil
     }
 
     /**
+	 * Does not work currently.
      * Assign {@link Identified}{@code s} to this fluid and its source fluid. Multiple calls will add additional tags.
      * 
      * @param tags
@@ -427,6 +425,7 @@ public class FluidBuilder<T extends SimpleFlowableFluid, P> extends AbstractBuil
     }
 
     /**
+	 * Does not work currently.
      * Remove {@link Identified}{@code s} from this fluid and its source fluid. Multiple calls will remove additional tags.
      * 
      * @param tags
@@ -444,21 +443,24 @@ public class FluidBuilder<T extends SimpleFlowableFluid, P> extends AbstractBuil
         Preconditions.checkNotNull(source, "Fluid has no source block: " + sourceName);
         return source.get();
     }
-    
-    private SimpleFlowableFluid.Properties makeProperties() {
-//        FluidAttributes.Builder attributes = this.attributes.get();
+	
+	/**
+	 * Does not work currently.
+	 */
+	private SimpleFlowableFluid.Properties makeProperties() {
+        FluidAttributes attributes = this.attributes.get();
         RegistryEntry<Block> block = getOwner().getOptional(sourceName, Block.class);
-//        attributesCallback.accept(attributes);
+        attributesCallback.accept(attributes);
         // Force the translation key after the user callback runs
         // This is done because we need to remove the lang data generator if using the block key,
         // and if it was possible to undo this change, it might result in the user translation getting
         // silently lost, as there's no good way to check whether the translation key was changed.
         // TODO improve this?
         if (block.isPresent()) {
-//            attributes.translationKey(block.get().getTranslationKey());
+            attributes.translationKey(block.get().getTranslationKey());
 //            setData(ProviderType.LANG, NonNullBiConsumer.noop());
         } else {
-//            attributes.translationKey(Util.createTranslationKey("fluid", new Identifier(getOwner().getModid(), sourceName)));
+            attributes.translationKey(Util.createTranslationKey("fluid", new Identifier(getOwner().getModid(), sourceName)));
         }
         SimpleFlowableFluid.Properties ret = new SimpleFlowableFluid.Properties(source, asSupplier()/*, attributes*/);
         properties.accept(ret);

--- a/src/main/java/com/tterrag/registrate/util/FluidAttributes.java
+++ b/src/main/java/com/tterrag/registrate/util/FluidAttributes.java
@@ -1,0 +1,172 @@
+package com.tterrag.registrate.util;
+
+import net.minecraft.fluid.Fluid;
+import net.minecraft.sound.SoundEvent;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.Rarity;
+import net.minecraft.util.Util;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * This class aims to replicate the functionality of the class in Forge under the same name.
+ */
+public class FluidAttributes {
+	public Object bucketVolume;
+	public String translationKey;
+	public Identifier stillTexture;
+	public Identifier flowingTexture;
+	@Nullable public Identifier overlayTexture;
+	public SoundEvent fillSound;
+	public SoundEvent emptySound;
+	public int luminosity = 0;
+	public int density = 1000;
+	public int temperature = 300;
+	public int viscosity = 1000;
+	public boolean isGaseous;
+	public Rarity rarity = Rarity.COMMON;
+	public int color;
+	
+	public FluidAttributes() {}
+	
+	public FluidAttributes(FluidAttributes attributes, Fluid fluid) {
+		this.bucketVolume(attributes.bucketVolume);
+		this.translationKey(attributes.translationKey);
+		this.stillTexture(attributes.stillTexture);
+		this.flowingTexture(attributes.flowingTexture);
+		this.overlayTexture(attributes.overlayTexture);
+		this.fillSound(attributes.fillSound);
+		this.emptySound(attributes.emptySound);
+		this.luminosity(attributes.luminosity);
+		this.density(attributes.density);
+		this.temperature(attributes.temperature);
+		this.viscosity(attributes.viscosity);
+		this.isGaseous(attributes.isGaseous);
+		this.rarity(attributes.rarity);
+		this.color(attributes.color);
+	}
+	
+	/**
+	 * This must be set per fluid, it has no default to prevent types interfering. Setting it to 1000 (an int) is recommended.
+	 *
+	 * Amount of fluid per bucket. Not static because Fabric still hasn't decided on a standard.
+	 * Is an object to allow for whatever type you want. Could be an int, could be a double, could be a float. Up to you.
+	 */
+	public FluidAttributes bucketVolume(Object volume) {
+		this.bucketVolume = volume;
+		return this;
+	}
+	
+	public FluidAttributes translationKey(String key) {
+		this.translationKey = key;
+		return this;
+	}
+	
+	public FluidAttributes stillTexture(Identifier identifier) {
+		this.stillTexture = identifier;
+		return this;
+	}
+	
+	
+	public FluidAttributes flowingTexture(Identifier identifier) {
+		this.flowingTexture = identifier;
+		return this;
+	}
+	
+	
+	public FluidAttributes overlayTexture(Identifier identifier) {
+		this.overlayTexture = identifier;
+		return this;
+	}
+	
+	
+	public FluidAttributes fillSound(SoundEvent sound) {
+		this.fillSound = sound;
+		return this;
+	}
+	
+	
+	public FluidAttributes emptySound(SoundEvent sound) {
+		this.emptySound = sound;
+		return this;
+	}
+	
+	/**
+	 * The light level emitted by this fluid.
+	 *
+	 * Default value is 0, as most fluids do not actively emit light.
+	 */
+	public FluidAttributes luminosity(int luminosity) {
+		this.luminosity = luminosity;
+		return this;
+	}
+	
+	/**
+	 * Density of the fluid - completely arbitrary; negative density indicates that the fluid is
+	 * lighter than air.
+	 *
+	 * Default value is approximately the real-life density of water in kg/m^3.
+	 */
+	public FluidAttributes density(int density) {
+		this.density = density;
+		return this;
+	}
+	
+	/**
+	 * Temperature of the fluid - completely arbitrary; higher temperature indicates that the fluid is
+	 * hotter than air.
+	 *
+	 * Default value is approximately the real-life room temperature of water in degrees Kelvin.
+	 */
+	public FluidAttributes temperature(int temp) {
+		this.temperature = temp;
+		return this;
+	}
+	
+	/**
+	 * Viscosity ("thickness") of the fluid - completely arbitrary; negative values are not
+	 * permissible.
+	 *
+	 * Default value is approximately the real-life density of water in m/s^2 (x10^-3).
+	 *
+	 * Higher viscosity means that a fluid flows more slowly, like molasses.
+	 * Lower viscosity means that a fluid flows more quickly, like helium.
+	 *
+	 */
+	public FluidAttributes viscosity(int viscosity) {
+		this.viscosity = viscosity;
+		return this;
+	}
+	
+	/**
+	 * This indicates if the fluid is gaseous.
+	 *
+	 * Generally this is associated with negative density fluids.
+	 */
+	public FluidAttributes isGaseous(boolean gaseous) {
+		this.isGaseous = gaseous;
+		return this;
+	}
+	
+	/**
+	 * The rarity of the fluid.
+	 *
+	 * Used primarily in tool tips.
+	 */
+	public FluidAttributes rarity(Rarity rarity) {
+		this.rarity = rarity;
+		return this;
+	}
+	
+	/**
+	 * Color used by universal bucket and the ModelFluid baked model.
+	 * Note that this int includes the alpha so converting this to RGB with alpha would be
+	 *   float r = ((color >> 16) & 0xFF) / 255f; // red
+	 *   float g = ((color >> 8) & 0xFF) / 255f; // green
+	 *   float b = ((color >> 0) & 0xFF) / 255f; // blue
+	 *   float a = ((color >> 24) & 0xFF) / 255f; // alpha
+	 */
+	public FluidAttributes color(int color) {
+		this.color = color;
+		return this;
+	}
+}


### PR DESCRIPTION
AllFluids in Create-Refabricated is now error-less (minus the rendering stuff) with these changes + a commit I have ready to push. 
There's a replacement for FluidAttributes which should be easy to drop-in replace wherever it's used. 